### PR TITLE
Fix configurartion using window.monacoEditorPath

### DIFF
--- a/src/client/embedded/EmbeddedStarter.ts
+++ b/src/client/embedded/EmbeddedStarter.ts
@@ -150,7 +150,7 @@ jQuery(function () {
     //@ts-ignore
     if(window.monacoEditorPath != null){
         //@ts-ignore
-        prefix = window.monacoEditorPath;
+        editorPath = window.monacoEditorPath;
     }
 
     //@ts-ignore


### PR DESCRIPTION
Use `window.monacoEditorPath` to override the default path to monaco editor instead of the prefix.