### PR TITLE
[Feature] Getter for `Group`s

### DIFF
--- a/src/client/runtimelibrary/graphics/Group.ts
+++ b/src/client/runtimelibrary/graphics/Group.ts
@@ -287,7 +287,19 @@ export class GroupClass extends Klass {
 
             }, false, false, 'Zeichnet alle Objekte dieser Group in ein Bild und verwendet fortan nur noch dieses Bild, ohne die Kindelemente der Group erneut zu zeichnen. Mit dieser Methode können komplexe Bilder (z.B. ein Sternenhimmel) aufgebaut und dann statisch gemacht werden. Nach dem Aufbau brauchen sie daher kaum mehr Rechenzeit.', false));
 
-
+            (<Klass>shapeType).addMethod(new Method("getParentGroup", new Parameterlist([
+            ]), this,
+                (parameters) => {
+    
+                    let o: RuntimeObject = parameters[0].value;
+                    let sh: ShapeHelper = o.intrinsicData["Actor"];
+    
+                    if (sh.testdestroyed("getParentGroup")) return;
+    
+                    return sh.getParentGroup();
+    
+                }, false, false, 'Gibt die Group zurück, in der sich das Grafikobjekt befindet, bzw. null, falls es in keiner Group ist.', false));
+    
     }
 
 }

--- a/src/client/runtimelibrary/graphics/Shape.ts
+++ b/src/client/runtimelibrary/graphics/Shape.ts
@@ -1,7 +1,7 @@
 import { Klass, Visibility } from "../../compiler/types/Class.js";
 import { Module } from "../../compiler/parser/Module.js";
 import { Method, Parameterlist, Attribute, Value, Type } from "../../compiler/types/Types.js";
-import { intPrimitiveType, doublePrimitiveType, voidPrimitiveType, booleanPrimitiveType, DoublePrimitiveType, stringPrimitiveType } from "../../compiler/types/PrimitiveTypes.js";
+import { intPrimitiveType, doublePrimitiveType, voidPrimitiveType, booleanPrimitiveType, DoublePrimitiveType, stringPrimitiveType, nullType } from "../../compiler/types/PrimitiveTypes.js";
 import { RuntimeObject } from "../../interpreter/RuntimeObject.js";
 import { ArrayType } from "../../compiler/types/Array.js";
 import { ActorHelper } from "./Actor.js";
@@ -683,7 +683,6 @@ export class ShapeClass extends Klass {
 
             }, false, false, "Gibt ein Array zurück, das die vier Eckpunkte des Hit-Polygons in Form von Vector2-Ortsvektoren enthält. Bei den Klassen Rectangle, Triangle und Polygon sind dies die Eckpunkte.", false));
 
-
     }
 
 }
@@ -1249,6 +1248,10 @@ export abstract class ShapeHelper extends ActorHelper {
                 list.splice(index, 1);
             }
         }
+    }
+
+    getParentGroup(): RuntimeObject {
+        return this.belongsToGroup?.runtimeObject || null
     }
 
 

--- a/src/client/runtimelibrary/graphics/World.ts
+++ b/src/client/runtimelibrary/graphics/World.ts
@@ -254,6 +254,19 @@ export class WorldClass extends Klass {
 
             }, false, false, 'Legt eine Gruppe fest, zu der ab jetzt alle neuen Objekte automatisch hinzugefügt werden. Falls null angegeben wird, werden neue Objekte zu keiner Gruppe automatisch hinzugefügt.', false));
 
+
+        this.addMethod(new Method("getDefaultGroup", new Parameterlist([
+        ]), groupType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let wh: WorldHelper = o.intrinsicData["World"];
+
+                return wh.getDefaultGroup();
+
+            }, false, false, 'Gibt die Gruppe zurück, zu der aktuell alle neuen Objekte automatisch hinzugefügt werden. Falls gerade keine defaultGroup festgelegt ist, wird null zurückgegeben.', false));
+
+
         this.addMethod(new Method("addMouseListener", new Parameterlist([
             { identifier: "listener", type: mouseListenerType, declaration: null, usagePositions: null, isFinal: true },
         ]), voidPrimitiveType,
@@ -1123,6 +1136,10 @@ export class WorldHelper {
             invoke([]);
         }
 
+    }
+
+    getDefaultGroup(): RuntimeObject {
+        return this.defaultGroup?.runtimeObject;
     }
 
 }


### PR DESCRIPTION
## Features
Added following methods:
* `Shape.getParentGroup()` returns the `Group` the `Shape` belongs to or `null`, if it is not in a `Group`.
* `World.getDefaultGroup()` returns the current `defaultGroup` of the `World` or `null`, if it isn't set.

## Why the feature is useful
I had the problem, that I wanted to get a reference on the `Group`, in which a `Shape` is, from a the method of the `Shape`. Currently the only workaround is to create a class inheriting from `Group`, that overwrites `add` and tells the shape it's parent group, when it is added to it (see our project [here](https://github.com/Informa-Tiger/online-ide-projects/blob/3657b320f0022d656204b4761717c3139dbdaa56/GameCollection11B/UI.java#L344)). But since the `Shape` knows, which `Group` it belongs to, it would make sense, to make a getter for the parent `Group` of a `Shape`.

Also I noticed that you can set the `defaultGroup` of a `World` with `setDefaultGroup(Group)`, but there is no `getDefaultGroup()`, which could be helpful, when you have a method that adds all drawn `Shapes` to a certain `Group` and want to set the `defaultGroup` to the previous again in the end, so that there are no problems, when calling it recursively.

## Examples
* Example for `getParentGroup()` <a href="https://informa-tiger.github.io/Online-IDE/htdocs/ide?s=https://raw.githubusercontent.com/Informa-Tiger/online-ide-projects/main/embedded_examples/pr_54_getParentGroup.java" target="_blank">**🡭 Start in IDE**</a>
  
   ```java
  class DeleteButton extends Rectangle {
     public DeleteButton(double x, double y) {
        super(x, y, 100, 100);
     }
     public void onMouseUp(double x, double y, int key) {
        if(getParentGroup() != null) getParentGroup().destroy();
        else destroy();
     }
  }
  
  new DeleteButton(0, 0);
  new Group(new DeleteButton(200,0), new Circle(250,250, 50));
  ```
  Result:
  ![image](https://user-images.githubusercontent.com/67505689/172132435-daacf511-8acc-4c51-986e-227292b42ba8.png)

* Example for `getDefaultGroup()`:  <a href="https://informa-tiger.github.io/Online-IDE/htdocs/ide?s=https://raw.githubusercontent.com/Informa-Tiger/online-ide-projects/main/embedded_examples/pr_54_getDefaultGroup.java" target="_blank">**🡭 Start in IDE**</a>

   ```java
  public class Test extends Group {
  
     public Test(int children) {
        Group lastDefaultGroup = getWorld().getDefaultGroup();
        getWorld().setDefaultGroup(this);
        
        Test child;
        if(children > 0) child = new Test(children - 1);
        new Rectangle(0, 0, 50, 50);
        if(child != null) child.move(50, 50);
        
        getWorld().setDefaultGroup(lastDefaultGroup);
     }
  }
  
  new Test(2);
   ```
   Result: 
![image](https://user-images.githubusercontent.com/67505689/172130281-3dca20fc-f2c9-4f07-936f-d12c0c24d5a2.png)
