### PR TITLE
[Bugfix] Fixed error when copying groups

### DIFF
--- a/src/client/runtimelibrary/graphics/Group.ts
+++ b/src/client/runtimelibrary/graphics/Group.ts
@@ -371,12 +371,7 @@ export class GroupHelper extends ShapeHelper {
             let roCopy: RuntimeObject = shapeHelper.getCopy(<Klass>ro.class)
             let shapeHelperCopy: ShapeHelper = roCopy.intrinsicData["Actor"];
 
-            groupHelperCopy.shapes.push(roCopy);
-
-            shapeHelperCopy.belongsToGroup = groupHelperCopy;
-
-            (<PIXI.Container>groupHelperCopy.displayObject).addChild(shapeHelperCopy.displayObject);
-
+            groupHelperCopy.add(roCopy);
         }
 
         groupHelperCopy.copyFrom(this);
@@ -462,7 +457,6 @@ export class GroupHelper extends ShapeHelper {
         let index = this.shapes.indexOf(shape);
         if (index >= 0) {
             this.shapes.splice(index, 1);
-
             this.deregister(shape, index);
         }
     }


### PR DESCRIPTION
 ##  When the bug occurs
It occurs, when you call `copy` of a `Group` object and have a default group set.

## Expected Behaviour
All elements of the `Group` should be copied and added to the copied `Group` (and only be in this `Group`).
The copied `Group` should be in the default Group.

## Bug
The elements are all copied and all in the copied `Group`. But they are also in the default group, which will eventually lead to an error, since a `Shape` is supposed to be only in one `Group` at the same time.

## How to reproduce this bug
The following example code should print, that there are `0` elements in the `defaultGroup`, but instead it prints `1`. That is because the `Rectangle` in `copy` remained in it.
```java
Rectangle r = new Rectangle(0, 0, 100, 100);
Group g = new Group(r);
Group defaultGroup = new Group();
defaultGroup.getWorld().setDefaultGroup(defaultGroup);
Group copy = g.copy();
g.destroy();
copy.destroy();
println(defaultGroup.size());
```

## Analysis
The problem is, how the copied `Shape` is added to the copied `Group` in [`GroupHelper.getCopy()`](https://github.com/martin-pabst/Online-IDE/blob/aa2d069c354cb6920dbf33acfe4095539bcf7cb1/src/client/runtimelibrary/graphics/Group.ts#L371-L378). This is done manually (instead of calling `add()`) and the copied `Shape` is not removed from `belongsToGroup`, which causes an error, if it is already in a `Group`, because it was automatically added to the default group.

## Bug fix
I added the copied `Shape` using `groupHelperCopy.add(roCopy);`, instead of doing it manually, so that it is automatically removed from the `Group` it belonged to before. You can check, that the code example now actually prints `0`, as it should, here: <a href="https://informa-tiger.github.io/Online-IDE/htdocs/ide?script=https://raw.githubusercontent.com/Informa-Tiger/online-ide-projects/main/embedded_examples/pr_55_Group_copy.java" target="_blank">**🡭 Start in IDE**</a>