### PR TITLE
[Discussion] [Bugfix] casts, automatic `toString()`, `null`, etc.

### DIFF
--- a/src/client/compiler/lexer/Lexer.ts
+++ b/src/client/compiler/lexer/Lexer.ts
@@ -914,7 +914,7 @@ export class Lexer {
         }
 
         if (this.currentChar == 'd' || this.currentChar == 'f') {
-            tt == TokenType.floatingPointConstant;
+            tt = TokenType.floatingPointConstant;
             this.next();
             if (radix != 10) {
                 this.pushError("Eine float/double-Konstante darf nicht mit 0, 0b oder 0x beginnen.", this.pos - posStart, "error", this.line, this.column - (this.pos - posStart));

--- a/src/client/compiler/types/Class.ts
+++ b/src/client/compiler/types/Class.ts
@@ -890,7 +890,7 @@ export class StaticClass extends Type {
         let attributes = this.getAttributes(Visibility.private);
         let object = this.classObject;
 
-        if(attributes == null) return "{}";
+        if (attributes == null) return "{}";
 
         for (let i = 0; i < attributes.length; i++) {
 
@@ -913,13 +913,13 @@ export class StaticClass extends Type {
         let itemList: monaco.languages.CompletionItem[] = [];
 
         for (let attribute of this.getAttributes(visibilityUpTo)) {
-            
+
             itemList.push({
                 label: attribute.identifier,
                 //@ts-ignore
-                detail: attribute.color? attribute.color : undefined,
+                detail: attribute.color ? attribute.color : undefined,
                 //@ts-ignore
-                kind: attribute.color? monaco.languages.CompletionItemKind.Color : monaco.languages.CompletionItemKind.Field,
+                kind: attribute.color ? monaco.languages.CompletionItemKind.Color : monaco.languages.CompletionItemKind.Field,
                 insertText: attribute.identifier,
                 range: rangeToReplace,
                 documentation: attribute.documentation == null ? undefined : {
@@ -1380,7 +1380,7 @@ function findSuitableMethods(methodList: Method[], identifier: string, parameter
                          * Bei f.berührt(r) gibt es eine Variante mit Parametertyp String (schlecht!) und
                          * eine mit Parametertyp Object. Letztere soll genommen werden, also:
                          */
-                        if(mParameterType == stringPrimitiveType) howManyCastings += 0.5;
+                        if (mParameterType == stringPrimitiveType) howManyCastings += 0.5;
                         continue;
                     }
 
@@ -1407,13 +1407,13 @@ function findSuitableMethods(methodList: Method[], identifier: string, parameter
 
                         if (givenType.canCastTo(mParameterTypeEllispsis)) {
                             howManyCastings++;
-                        /**
-                         * Rechteck r; 
-                         * GNGFigur f;
-                         * Bei f.berührt(r) gibt es eine Variante mit Parametertyp String (schlecht!) und
-                         * eine mit Parametertyp Object. Letztere soll genommen werden, also:
-                         */
-                         if(mParameterTypeEllispsis == stringPrimitiveType) howManyCastings += 0.5;
+                            /**
+                             * Rechteck r; 
+                             * GNGFigur f;
+                             * Bei f.berührt(r) gibt es eine Variante mit Parametertyp String (schlecht!) und
+                             * eine mit Parametertyp Object. Letztere soll genommen werden, also:
+                             */
+                            if (mParameterTypeEllispsis == stringPrimitiveType) howManyCastings += 0.5;
                             continue;
                         }
 
@@ -1487,3 +1487,20 @@ export function getVisibilityUpTo(objectType: Klass | StaticClass, currentClassC
 
 }
 
+
+export class UnboxableKlass extends Klass {
+
+    public unboxableAs: Type[] = [];
+
+    public castTo(value: Value, type: Type): Value {
+        if (! (type instanceof PrimitiveType)) return null;
+        if (this.unboxableAs.includes(type)) {
+            if (value.value == null && ! type.allowsNull()) throw Error("null kann nicht in einen primitiven " + type.identifier + " umgewandelt werden.");
+            else return {
+                value: value.value,
+                type: type
+            }
+        }
+        return null;
+    }
+}

--- a/src/client/compiler/types/Class.ts
+++ b/src/client/compiler/types/Class.ts
@@ -622,9 +622,7 @@ export class Klass extends Type {
 
     public canCastTo(type: Type): boolean {
 
-        if (type == stringPrimitiveType) {
-            return true;
-        }
+        // casting something to a String by calling toString() is neither possible in Java nor makes sense in my opinion
 
         if (type instanceof Klass) {
             let baseClass: Klass = this;

--- a/src/client/compiler/types/Class.ts
+++ b/src/client/compiler/types/Class.ts
@@ -1493,9 +1493,9 @@ export class UnboxableKlass extends Klass {
     public unboxableAs: Type[] = [];
 
     public castTo(value: Value, type: Type): Value {
-        if (! (type instanceof PrimitiveType)) return null;
+        if (!(type instanceof PrimitiveType)) return null;
         if (this.unboxableAs.includes(type)) {
-            if (value.value == null && ! type.allowsNull()) throw Error("null kann nicht in einen primitiven " + type.identifier + " umgewandelt werden.");
+            if (value.value == null && !type.allowsNull()) throw Error("null kann nicht in einen primitiven " + type.identifier + " umgewandelt werden.");
             else return {
                 value: value.value,
                 type: type
@@ -1503,4 +1503,9 @@ export class UnboxableKlass extends Klass {
         }
         return null;
     }
+
+    canCastTo(type: Type): boolean {
+        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
+    }
+
 }

--- a/src/client/compiler/types/PrimitiveTypes.ts
+++ b/src/client/compiler/types/PrimitiveTypes.ts
@@ -1,4 +1,4 @@
-import { TokenType } from "../lexer/Token.js";
+import { TokenType, TokenTypeReadable } from "../lexer/Token.js";
 import { ArrayType } from "./Array.js";
 import { Interface, Klass, setBooleanPrimitiveTypeCopy } from "./Class.js";
 import { ObjectClass } from "./ObjectClass.js";
@@ -9,6 +9,7 @@ import { FloatClass } from "./boxedTypes/FloatClass.js";
 import { CharacterClass } from "./boxedTypes/CharacterClass.js";
 import { BooleanClass } from "./boxedTypes/BooleanClass.js";
 import { DoubleClass } from "./boxedTypes/DoubleClass.js";
+import { floatToString, nullToString } from "../../tools/StringTools.js";
 
 export class NullType extends Type {
 
@@ -107,7 +108,6 @@ export class IntPrimitiveType extends PrimitiveType {
         this.canCastToMap = {
             "float": { automatic: true, needsStatement: false },
             "double": { automatic: true, needsStatement: false },
-            "String": { automatic: true, needsStatement: true },
             "char": { automatic: true, needsStatement: true },
             "int": { automatic: true, needsStatement: false },
             "long": { automatic: true, needsStatement: false },
@@ -129,14 +129,6 @@ export class IntPrimitiveType extends PrimitiveType {
                 value: value.value
             };
         }
-
-        if (type == stringPrimitiveType) {
-            return {
-                type: type,
-                value: "" + <number>value.value
-            }
-        }
-
         if (type == charPrimitiveType) {
             return {
                 type: type,
@@ -279,7 +271,6 @@ export class LongPrimitiveType extends IntPrimitiveType {
         this.canCastToMap = {
             "float": { automatic: true, needsStatement: false },
             "double": { automatic: true, needsStatement: false },
-            "String": { automatic: true, needsStatement: true },
             "char": { automatic: true, needsStatement: true },
             "int": { automatic: false, needsStatement: false },
             "long": { automatic: true, needsStatement: false },
@@ -328,9 +319,8 @@ export class FloatPrimitiveType extends PrimitiveType {
             "int": { automatic: false, needsStatement: true },
             "double": { automatic: true, needsStatement: false },
             "float": { automatic: true, needsStatement: false },
-            "String": { automatic: true, needsStatement: true },
-            "Float": { automatic: true, needsStatement: false },
-            "Double": { automatic: true, needsStatement: false },
+            "Float": { automatic: true, needsStatement: true },
+            "Double": { automatic: true, needsStatement: true },
         }
 
     }
@@ -340,13 +330,6 @@ export class FloatPrimitiveType extends PrimitiveType {
     }
 
     public castTo(value: Value, type: Type): Value {
-
-        if (type == stringPrimitiveType) {
-            return {
-                type: type,
-                value: "" + <number>value.value
-            }
-        }
 
         if (type == intPrimitiveType) {
             return {
@@ -362,6 +345,8 @@ export class FloatPrimitiveType extends PrimitiveType {
             }
         }
 
+    public valueToString(value: Value): string {
+        return floatToString(value.value);
     }
 
 
@@ -457,9 +442,8 @@ export class DoublePrimitiveType extends PrimitiveType {
             "int": { automatic: false, needsStatement: true },
             "float": { automatic: true, needsStatement: false },
             "double": { automatic: true, needsStatement: false },
-            "String": { automatic: true, needsStatement: true },
-            "Float": { automatic: true, needsStatement: false },
-            "Double": { automatic: true, needsStatement: false },
+            "Float": { automatic: true, needsStatement: true },
+            "Double": { automatic: true, needsStatement: true },
         }
 
 
@@ -470,13 +454,6 @@ export class DoublePrimitiveType extends PrimitiveType {
     }
 
     public castTo(value: Value, type: Type): Value {
-
-        if (type == stringPrimitiveType) {
-            return {
-                type: type,
-                value: "" + <number>value.value
-            }
-        }
 
         if (type == intPrimitiveType) {
             return {
@@ -492,7 +469,10 @@ export class DoublePrimitiveType extends PrimitiveType {
             }
         }
 
+    public valueToString(value: Value): string {
+        return floatToString(value.value);
     }
+
 
 
     public compute(operation: TokenType, firstOperand: Value, secondOperand?: Value): any {
@@ -576,7 +556,6 @@ export class BooleanPrimitiveType extends PrimitiveType {
         };
 
         this.canCastToMap = {
-            "String": { automatic: true, needsStatement: true },
             "boolean": { automatic: true, needsStatement: false },
             "Boolean": { automatic: true, needsStatement: false },
         }
@@ -590,12 +569,6 @@ export class BooleanPrimitiveType extends PrimitiveType {
 
     public castTo(value: Value, type: Type): Value {
 
-        if (type == stringPrimitiveType) {
-            return {
-                type: type,
-                value: "" + <number>value.value
-            }
-        }
 
     }
 
@@ -868,6 +841,8 @@ export class StringPrimitiveType extends Klass {
 
 
     }
+
+    public allowsNull(): boolean { return true; }
 
     public debugOutput(value: Value): string {
         return '"' + <string>value.value + '"';

--- a/src/client/compiler/types/PrimitiveTypes.ts
+++ b/src/client/compiler/types/PrimitiveTypes.ts
@@ -686,9 +686,7 @@ export class StringPrimitiveType extends Klass {
     init() {
         this.operationTable = {
             [TokenType.plus]: {
-                "String": stringPrimitiveType //, "int": stringPrimitiveType,
-                // "float": stringPrimitiveType, "double": stringPrimitiveType,
-                // "boolean": stringPrimitiveType, "char": stringPrimitiveType
+                "String": stringPrimitiveType
             },
             [TokenType.equal]: { "String": booleanPrimitiveType, "null": booleanPrimitiveType },
             [TokenType.notEqual]: { "String": booleanPrimitiveType, "null": booleanPrimitiveType },
@@ -805,12 +803,8 @@ export class StringPrimitiveType extends Klass {
 
         switch (operation) {
             case TokenType.plus:
-                if (secondOperand.type == stringPrimitiveType || secondOperand.type == charPrimitiveType) {
+                if (secondOperand.type == stringPrimitiveType) {
                     return nullToString(value) + <string>(secondOperand.value); // because null + null = 0 in javascript
-                } else if (secondOperand.type == booleanPrimitiveType) {
-                    return nullToString(value) + <boolean>(secondOperand.value);
-                } else {
-                    return nullToString(value) + <number>(secondOperand.value);
                 }
 
             case TokenType.lower:

--- a/src/client/compiler/types/PrimitiveTypes.ts
+++ b/src/client/compiler/types/PrimitiveTypes.ts
@@ -118,6 +118,7 @@ export class IntPrimitiveType extends PrimitiveType {
             "int": { automatic: true, needsStatement: false },
             "long": { automatic: true, needsStatement: false },
             "Integer": { automatic: true, needsStatement: true },
+            "Long": { automatic: true, needsStatement: true },
         }
 
 

--- a/src/client/compiler/types/PrimitiveTypes.ts
+++ b/src/client/compiler/types/PrimitiveTypes.ts
@@ -19,9 +19,12 @@ export class NullType extends Type {
     }
 
     getResultType(operation: TokenType, secondOperandType: Type) {
-        return null;
+        if (operation == TokenType.equal || operation == TokenType.notEqual) return secondOperandType.getResultType(operation,this);
     }
     compute(operation: TokenType, firstOperand: Value, secondOperand: Value) {
+        if (operation == TokenType.equal || operation == TokenType.notEqual) {
+            return (firstOperand.value == secondOperand.value) == (operation == TokenType.equal);
+        }
         return null;
     }
     canCastTo(type: Type) {

--- a/src/client/compiler/types/PrimitiveTypes.ts
+++ b/src/client/compiler/types/PrimitiveTypes.ts
@@ -28,7 +28,10 @@ export class NullType extends Type {
         return (type instanceof Klass || type instanceof Interface || type instanceof ArrayType);
     }
     castTo(value: Value, type: Type) {
-        return value;
+        return {
+            value: value.value,
+            type: type
+        };
     }
     equals(type: Type) {
         return (type instanceof Klass || type instanceof Interface);
@@ -77,7 +80,7 @@ export class IntPrimitiveType extends PrimitiveType {
         this.description = "ganze Zahl"
 
         this.operationTable = {
-            [TokenType.plus]: { "long": longPrimitiveType, "Long": longPrimitiveType, "int": intPrimitiveType, "Integer": intPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType, "String": stringPrimitiveType },
+            [TokenType.plus]: { "long": longPrimitiveType, "Long": longPrimitiveType, "int": intPrimitiveType, "Integer": intPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.minus]: { "none": intPrimitiveType, "long": longPrimitiveType, "Long": longPrimitiveType, "int": intPrimitiveType, "Integer": intPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.multiplication]: { "long": longPrimitiveType, "Long": longPrimitiveType, "int": intPrimitiveType, "Integer": intPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.modulo]: { "long": longPrimitiveType, "Long": longPrimitiveType, "int": intPrimitiveType, "Integer": intPrimitiveType },
@@ -111,7 +114,7 @@ export class IntPrimitiveType extends PrimitiveType {
             "char": { automatic: true, needsStatement: true },
             "int": { automatic: true, needsStatement: false },
             "long": { automatic: true, needsStatement: false },
-            "Integer": { automatic: true, needsStatement: false },
+            "Integer": { automatic: true, needsStatement: true },
         }
 
 
@@ -123,12 +126,6 @@ export class IntPrimitiveType extends PrimitiveType {
 
     public castTo(value: Value, type: Type): Value {
 
-        if (type == floatPrimitiveType || type == doublePrimitiveType) {
-            return {
-                type: type,
-                value: value.value
-            };
-        }
         if (type == charPrimitiveType) {
             return {
                 type: type,
@@ -240,7 +237,7 @@ export class LongPrimitiveType extends IntPrimitiveType {
         this.description = "ganze Zahl"
 
         this.operationTable = {
-            [TokenType.plus]: { "long": longPrimitiveType, "int": longPrimitiveType, "Long": longPrimitiveType, "Integer": longPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType, "String": stringPrimitiveType },
+            [TokenType.plus]: { "long": longPrimitiveType, "int": longPrimitiveType, "Long": longPrimitiveType, "Integer": longPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.minus]: { "none": intPrimitiveType, "long": longPrimitiveType, "int": longPrimitiveType, "Long": longPrimitiveType, "Integer": longPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.multiplication]: { "long": longPrimitiveType, "int": longPrimitiveType, "Long": longPrimitiveType, "Integer": longPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.modulo]: { "long": longPrimitiveType, "int": longPrimitiveType, "Long": longPrimitiveType, "Integer": longPrimitiveType },
@@ -298,7 +295,7 @@ export class FloatPrimitiveType extends PrimitiveType {
         this.description = "Fließkommazahl mit einfacher Genauigkeit"
 
         this.operationTable = {
-            [TokenType.plus]: { "Integer": floatPrimitiveType, "int": floatPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType, "String": stringPrimitiveType },
+            [TokenType.plus]: { "Integer": floatPrimitiveType, "int": floatPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.minus]: { "none": floatPrimitiveType, "Integer": floatPrimitiveType, "int": floatPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.multiplication]: { "Integer": floatPrimitiveType, "int": floatPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.division]: { "Integer": floatPrimitiveType, "int": floatPrimitiveType, "float": floatPrimitiveType, "Float": floatPrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
@@ -338,12 +335,14 @@ export class FloatPrimitiveType extends PrimitiveType {
             }
         }
 
-        if (type == doublePrimitiveType) {
-            return {
-                type: type,
-                value: value.value
-            }
-        }
+        // if (type == doublePrimitiveType || type == DoubleType || type == FloatType) {
+        //     return {
+        //         type: type,
+        //         value: value.value
+        //     }
+        // }
+
+    }
 
     public valueToString(value: Value): string {
         return floatToString(value.value);
@@ -422,7 +421,7 @@ export class DoublePrimitiveType extends PrimitiveType {
         this.description = "Fließkommazahl mit doppelter Genauigkeit"
 
         this.operationTable = {
-            [TokenType.plus]: { "int": doublePrimitiveType, "Integer": doublePrimitiveType, "float": doublePrimitiveType, "Float": doublePrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType, "String": stringPrimitiveType },
+            [TokenType.plus]: { "int": doublePrimitiveType, "Integer": doublePrimitiveType, "float": doublePrimitiveType, "Float": doublePrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.minus]: { "none": doublePrimitiveType, "int": doublePrimitiveType, "Integer": doublePrimitiveType, "float": doublePrimitiveType, "Float": doublePrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.multiplication]: { "int": doublePrimitiveType, "Integer": doublePrimitiveType, "float": doublePrimitiveType, "Float": doublePrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
             [TokenType.division]: { "int": doublePrimitiveType, "Integer": doublePrimitiveType, "float": doublePrimitiveType, "Float": doublePrimitiveType, "double": doublePrimitiveType, "Double": doublePrimitiveType },
@@ -462,12 +461,7 @@ export class DoublePrimitiveType extends PrimitiveType {
             }
         }
 
-        if (type == floatPrimitiveType) {
-            return {
-                type: type,
-                value: value.value
-            }
-        }
+    }
 
     public valueToString(value: Value): string {
         return floatToString(value.value);
@@ -547,7 +541,7 @@ export class BooleanPrimitiveType extends PrimitiveType {
         this.description = "boolescher Wert (true oder false)"
 
         this.operationTable = {
-            [TokenType.plus]: { "String": stringPrimitiveType },
+            [TokenType.plus]: {},
             [TokenType.and]: { "boolean": booleanPrimitiveType },
             [TokenType.or]: { "boolean": booleanPrimitiveType },
             [TokenType.not]: { "none": booleanPrimitiveType },
@@ -557,7 +551,7 @@ export class BooleanPrimitiveType extends PrimitiveType {
 
         this.canCastToMap = {
             "boolean": { automatic: true, needsStatement: false },
-            "Boolean": { automatic: true, needsStatement: false },
+            "Boolean": { automatic: true, needsStatement: true },
         }
 
 
@@ -569,6 +563,7 @@ export class BooleanPrimitiveType extends PrimitiveType {
 
     public castTo(value: Value, type: Type): Value {
 
+        return undefined;
 
     }
 
@@ -579,7 +574,7 @@ export class BooleanPrimitiveType extends PrimitiveType {
 
         switch (operation) {
             case TokenType.plus:
-                return value + <string>(secondOperand.value);
+                return value + nullToString(<string>(secondOperand.value));
 
             case TokenType.equal:
                 return value == <boolean>(secondOperand.value);
@@ -688,9 +683,9 @@ export class StringPrimitiveType extends Klass {
     init() {
         this.operationTable = {
             [TokenType.plus]: {
-                "String": stringPrimitiveType, "int": stringPrimitiveType,
-                "float": stringPrimitiveType, "double": doublePrimitiveType,
-                "boolean": stringPrimitiveType, "char": stringPrimitiveType
+                "String": stringPrimitiveType //, "int": stringPrimitiveType,
+                // "float": stringPrimitiveType, "double": stringPrimitiveType,
+                // "boolean": stringPrimitiveType, "char": stringPrimitiveType
             },
             [TokenType.equal]: { "String": booleanPrimitiveType, "null": booleanPrimitiveType },
             [TokenType.notEqual]: { "String": booleanPrimitiveType, "null": booleanPrimitiveType },
@@ -802,14 +797,17 @@ export class StringPrimitiveType extends Klass {
 
         let value = <string>(firstOperand.value);
 
+        let err: Error = checkNotNull(operation, this, firstOperand, secondOperand, [TokenType.plus, TokenType.keywordInstanceof])
+        if (err != null) return err;
+
         switch (operation) {
             case TokenType.plus:
                 if (secondOperand.type == stringPrimitiveType || secondOperand.type == charPrimitiveType) {
-                    return value + <string>(secondOperand.value);
+                    return nullToString(value) + <string>(secondOperand.value); // because null + null = 0 in javascript
                 } else if (secondOperand.type == booleanPrimitiveType) {
-                    return value + <boolean>(secondOperand.value);
+                    return nullToString(value) + <boolean>(secondOperand.value);
                 } else {
-                    return value + <number>(secondOperand.value);
+                    return nullToString(value) + <number>(secondOperand.value);
                 }
 
             case TokenType.lower:
@@ -877,9 +875,9 @@ export class CharPrimitiveType extends PrimitiveType {
             "int": { automatic: true, needsStatement: true },
             "float": { automatic: true, needsStatement: true },
             "double": { automatic: true, needsStatement: true },
-            "String": { automatic: true, needsStatement: false },
+            "String": { automatic: true, needsStatement: true },
             "char": { automatic: true, needsStatement: false },
-            "Character": { automatic: true, needsStatement: false },
+            "Character": { automatic: true, needsStatement: true },
         }
 
     }
@@ -890,9 +888,15 @@ export class CharPrimitiveType extends PrimitiveType {
 
     public castTo(value: Value, type: Type): Value {
 
-        if (type == stringPrimitiveType) {
-            return value;
-        }
+        // let unboxed = this.unboxFrom(value, type);
+        // if (unboxed != null) return unboxed;
+
+        // if (type == stringPrimitiveType || type == CharacterType) {
+        //     return {
+        //         type: type,
+        //         value: value
+        //     }
+        // }
 
         if (type == intPrimitiveType || type == floatPrimitiveType || type == doublePrimitiveType) {
             return {
@@ -969,4 +973,20 @@ export var TokenTypeToDataTypeMap: { [tt: number]: Type } = {
     [TokenType.stringConstant]: stringPrimitiveType,
     [TokenType.charConstant]: charPrimitiveType,
     [TokenType.keywordNull]: nullType
+}
+
+
+function checkNotNull(operation: TokenType, type: Type, firstOperand: Value, secondOperand?: Value, nullAllowedFor: TokenType[] = []): Error {
+    if ((firstOperand.value == null || secondOperand.value == null) && !nullAllowedFor.concat([TokenType.equal, TokenType.notEqual]).includes(operation)) {
+        let typeAndNull: (v: Value) => string = (v: Value) => v.value == null ? "(" + type.identifier + ")" + " null" : type.identifier;
+        return new OperandIsNull("Unerlaubte Rechnung mit null: " + typeAndNull(firstOperand) + " " + TokenTypeReadable[operation] + " " + typeAndNull(secondOperand));
+    }
+    return null;
+}
+
+export class OperandIsNull extends Error {
+    constructor(message?: string) {
+        super(message);
+        this.name = "OperandIsNullError";
+    }
 }

--- a/src/client/compiler/types/Types.ts
+++ b/src/client/compiler/types/Types.ts
@@ -3,7 +3,7 @@ import { TextPosition, TokenType } from "../lexer/Token.js";
 import { Module } from "../parser/Module.js";
 import { Program } from "../parser/Program.js";
 import { ArrayType } from "./Array.js";
-import { Visibility, TypeVariable } from "./Class.js";
+import { Visibility } from "./Class.js";
 
 export type UsagePositions = Map<Module, TextPosition[]>;
 
@@ -89,6 +89,12 @@ export abstract class PrimitiveType extends Type {
 
     public getCastInformation(type: Type): CastInformation {
         return this.canCastToMap[type.identifier];
+    }
+
+    public allowsNull(): boolean { return false; }
+
+    public valueToString(value: Value): string {
+        return  "" + value.value;
     }
 
 }

--- a/src/client/compiler/types/boxedTypes/BooleanClass.ts
+++ b/src/client/compiler/types/boxedTypes/BooleanClass.ts
@@ -18,10 +18,6 @@ export class BooleanClass extends UnboxableKlass {
 
     }
 
-    canCastTo(type: Type): boolean {
-        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
-    }
-
     init() {
 
         this.unboxableAs = [booleanPrimitiveType];

--- a/src/client/compiler/types/boxedTypes/BooleanClass.ts
+++ b/src/client/compiler/types/boxedTypes/BooleanClass.ts
@@ -1,12 +1,10 @@
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
-import { Klass, Visibility } from "../Class.js";
+import { Klass, UnboxableKlass, Visibility } from "../Class.js";
 import { booleanPrimitiveType, charPrimitiveType, intPrimitiveType, stringPrimitiveType } from "../PrimitiveTypes.js";
 import { Method, Parameterlist, Type, Value, Attribute } from "../Types.js";
 
 
-export class BooleanClass extends Klass {
-
-    unboxableAs = [];
+export class BooleanClass extends UnboxableKlass {
 
     constructor(baseClass: Klass) {
         super("Boolean", null, "Wrapper-Klasse, um boolean-Werte in Collections verenden zu können.");

--- a/src/client/compiler/types/boxedTypes/CharacterClass.ts
+++ b/src/client/compiler/types/boxedTypes/CharacterClass.ts
@@ -1,12 +1,10 @@
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
-import { Klass } from "../Class.js";
+import { Klass, UnboxableKlass } from "../Class.js";
 import { booleanPrimitiveType, charPrimitiveType, intPrimitiveType, stringPrimitiveType } from "../PrimitiveTypes.js";
 import { Method, Parameterlist, Type, Value } from "../Types.js";
 
 
-export class CharacterClass extends Klass {
-
-    unboxableAs = [];
+export class CharacterClass extends UnboxableKlass {
 
     constructor(baseClass: Klass) {
         super("Character", null, "Wrapper-Klasse, um char-Werte in Collections verenden zu können.");
@@ -152,6 +150,5 @@ export class CharacterClass extends Klass {
     public debugOutput(value: Value): string {
         return "" + <number>value.value;
     }
-
 
 }

--- a/src/client/compiler/types/boxedTypes/CharacterClass.ts
+++ b/src/client/compiler/types/boxedTypes/CharacterClass.ts
@@ -15,10 +15,6 @@ export class CharacterClass extends UnboxableKlass {
 
     }
 
-    canCastTo(type: Type): boolean {
-        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
-    }
-
     init() {
 
         this.unboxableAs = [charPrimitiveType, stringPrimitiveType];

--- a/src/client/compiler/types/boxedTypes/DoubleClass.ts
+++ b/src/client/compiler/types/boxedTypes/DoubleClass.ts
@@ -106,7 +106,7 @@ export class DoubleClass extends UnboxableKlass {
             { identifier: "f", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true }
         ]), stringPrimitiveType,
             (parameters) => {
-                return "" + parameters[1].value;
+                return floatToString(parameters[1].value);
             }, false, true, "Gibt die übergebene Zahl als String-Wert zurück."));
 
         this.addMethod(new Method("valueOf", new Parameterlist([

--- a/src/client/compiler/types/boxedTypes/DoubleClass.ts
+++ b/src/client/compiler/types/boxedTypes/DoubleClass.ts
@@ -1,12 +1,11 @@
-import { Klass, Visibility } from "../Class.js";
+import { Klass, UnboxableKlass, Visibility } from "../Class.js";
 import { Method, Parameterlist, Attribute, Value, Type, PrimitiveType } from "../Types.js";
 import { intPrimitiveType, stringPrimitiveType, floatPrimitiveType, doublePrimitiveType, booleanPrimitiveType } from "../PrimitiveTypes.js";
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
+import { floatToString } from "../../../tools/StringTools.js";
 
 
-export class DoubleClass extends Klass {
-
-    unboxableAs = [];
+export class DoubleClass extends UnboxableKlass {
 
     constructor(baseClass: Klass) {
         super("Double", null, "Wrapper-Klasse, um double-Werte in Collections verenden zu können.");
@@ -87,7 +86,7 @@ export class DoubleClass extends Klass {
         this.addMethod(new Method("toString", new Parameterlist([
         ]), stringPrimitiveType,
             (parameters) => {
-                return "" + parameters[0].value;
+                return floatToString(parameters[0].value);
             }, false, false, "Gibt den Wert des Objekts als String-Wert zurück."));
 
         this.addMethod(new Method("hashCode", new Parameterlist([

--- a/src/client/compiler/types/boxedTypes/DoubleClass.ts
+++ b/src/client/compiler/types/boxedTypes/DoubleClass.ts
@@ -22,10 +22,6 @@ export class DoubleClass extends UnboxableKlass {
 
     }
 
-    canCastTo(type: Type): boolean {
-        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
-    }
-
     init() {
 
         this.unboxableAs = [doublePrimitiveType];

--- a/src/client/compiler/types/boxedTypes/FloatClass.ts
+++ b/src/client/compiler/types/boxedTypes/FloatClass.ts
@@ -106,7 +106,7 @@ export class FloatClass extends UnboxableKlass {
             { identifier: "f", type: floatPrimitiveType, declaration: null, usagePositions: null, isFinal: true }
         ]), stringPrimitiveType,
             (parameters) => {
-                return "" + parameters[1].value;
+                return floatToString(parameters[1].value);
             }, false, true, "Gibt die übergebene Zahl als String-Wert zurück."));
 
         this.addMethod(new Method("valueOf", new Parameterlist([

--- a/src/client/compiler/types/boxedTypes/FloatClass.ts
+++ b/src/client/compiler/types/boxedTypes/FloatClass.ts
@@ -22,10 +22,6 @@ export class FloatClass extends UnboxableKlass {
 
     }
 
-    canCastTo(type: Type): boolean {
-        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
-    }
-
     init() {
 
         this.unboxableAs = [floatPrimitiveType, doublePrimitiveType];

--- a/src/client/compiler/types/boxedTypes/FloatClass.ts
+++ b/src/client/compiler/types/boxedTypes/FloatClass.ts
@@ -1,12 +1,11 @@
-import { Klass, Visibility } from "../Class.js";
+import { Klass, UnboxableKlass, Visibility } from "../Class.js";
 import { Method, Parameterlist, Attribute, Value, Type, PrimitiveType } from "../Types.js";
 import { intPrimitiveType, stringPrimitiveType, doublePrimitiveType, floatPrimitiveType, booleanPrimitiveType } from "../PrimitiveTypes.js";
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
+import { floatToString } from "../../../tools/StringTools.js";
 
 
-export class FloatClass extends Klass {
-
-    unboxableAs = [];
+export class FloatClass extends UnboxableKlass {
 
     constructor(baseClass: Klass) {
         super("Float", null, "Wrapper-Klasse, um float-Werte in Collections verenden zu können.");
@@ -87,7 +86,7 @@ export class FloatClass extends Klass {
         this.addMethod(new Method("toString", new Parameterlist([
         ]), stringPrimitiveType,
             (parameters) => {
-                return "" + parameters[0].value;
+                return floatToString(parameters[0].value);
             }, false, false, "Gibt den Wert des Objekts als String-Wert zurück."));
 
         this.addMethod(new Method("hashCode", new Parameterlist([

--- a/src/client/compiler/types/boxedTypes/IntegerClass.ts
+++ b/src/client/compiler/types/boxedTypes/IntegerClass.ts
@@ -19,10 +19,6 @@ export class IntegerClass extends UnboxableKlass {
 
     }
 
-    canCastTo(type: Type): boolean{
-        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
-    }
-
     init() {
 
         this.unboxableAs = [intPrimitiveType, floatPrimitiveType, doublePrimitiveType];

--- a/src/client/compiler/types/boxedTypes/IntegerClass.ts
+++ b/src/client/compiler/types/boxedTypes/IntegerClass.ts
@@ -1,12 +1,10 @@
-import { Klass, Visibility } from "../Class.js";
+import { Klass, UnboxableKlass, Visibility } from "../Class.js";
 import { Method, Parameterlist, Attribute, Value, Type, PrimitiveType } from "../Types.js";
 import { intPrimitiveType, stringPrimitiveType, doublePrimitiveType, floatPrimitiveType, booleanPrimitiveType } from "../PrimitiveTypes.js";
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
 
 
-export class IntegerClass extends Klass {
-
-    unboxableAs = [];
+export class IntegerClass extends UnboxableKlass {
 
     constructor(baseClass: Klass) {
         super("Integer", null, "Wrapper-Klasse, um int-Werte in Collections verenden zu können.");

--- a/src/client/compiler/types/boxedTypes/IntegerClass.ts
+++ b/src/client/compiler/types/boxedTypes/IntegerClass.ts
@@ -1,6 +1,6 @@
 import { Klass, UnboxableKlass, Visibility } from "../Class.js";
 import { Method, Parameterlist, Attribute, Value, Type, PrimitiveType } from "../Types.js";
-import { intPrimitiveType, stringPrimitiveType, doublePrimitiveType, floatPrimitiveType, booleanPrimitiveType } from "../PrimitiveTypes.js";
+import { intPrimitiveType, stringPrimitiveType, doublePrimitiveType, floatPrimitiveType, booleanPrimitiveType, longPrimitiveType } from "../PrimitiveTypes.js";
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
 
 
@@ -21,7 +21,7 @@ export class IntegerClass extends UnboxableKlass {
 
     init() {
 
-        this.unboxableAs = [intPrimitiveType, floatPrimitiveType, doublePrimitiveType];
+        this.unboxableAs = [intPrimitiveType, floatPrimitiveType, doublePrimitiveType, longPrimitiveType];
 
         this.addMethod(new Method("Integer", new Parameterlist([
             { identifier: "int-wert", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true }

--- a/src/client/compiler/types/boxedTypes/LongClass.ts
+++ b/src/client/compiler/types/boxedTypes/LongClass.ts
@@ -19,10 +19,6 @@ export class LongClass extends UnboxableKlass {
 
     }
 
-    canCastTo(type: Type): boolean{
-        return this.unboxableAs.indexOf(type) >= 0 || super.canCastTo(type);
-    }
-
     init() {
 
         this.unboxableAs = [intPrimitiveType, longPrimitiveType, floatPrimitiveType, doublePrimitiveType];

--- a/src/client/compiler/types/boxedTypes/LongClass.ts
+++ b/src/client/compiler/types/boxedTypes/LongClass.ts
@@ -1,12 +1,10 @@
-import { Klass, Visibility } from "../Class.js";
+import { Klass, UnboxableKlass, Visibility } from "../Class.js";
 import { Method, Parameterlist, Attribute, Value, Type, PrimitiveType } from "../Types.js";
 import { longPrimitiveType, stringPrimitiveType, doublePrimitiveType, floatPrimitiveType, intPrimitiveType, booleanPrimitiveType } from "../PrimitiveTypes.js";
 import { RuntimeObject } from "../../../interpreter/RuntimeObject.js";
 
 
-export class LongClass extends Klass {
-
-    unboxableAs = [];
+export class LongClass extends UnboxableKlass {
 
     constructor(baseClass: Klass) {
         super("Long", null, "Wrapper-Klasse, um int-Werte in Collections verenden zu können.");

--- a/src/client/interpreter/Interpreter.ts
+++ b/src/client/interpreter/Interpreter.ts
@@ -678,7 +678,7 @@ export class Interpreter {
             this.worldHelper.cacheAsBitmap();
         }
 
-        this.databaseConnectionHelpers.forEach((ch)=> ch.close());
+        this.databaseConnectionHelpers.forEach((ch) => ch.close());
         this.databaseConnectionHelpers = [];
 
         this.heap = {};
@@ -833,7 +833,17 @@ export class Interpreter {
             case TokenType.castValue:
                 let relPos = node.stackPosRelative == null ? 0 : node.stackPosRelative;
                 value = stack[stackTop + relPos];
-                stack[stackTop + relPos] = value.type.castTo(value, node.newType);
+                try {
+                    let casted = value.type.castTo(value, node.newType);
+                    if (casted == undefined) casted = {
+                        value: value.value,
+                        type: node.newType
+                    }
+                    stack[stackTop + relPos] = casted;
+                } catch (err) {
+                    if (err.message) return err.message;
+                    else return "Bei dem Casten von " + value.type.identifier + " zu " + node.newType.identifier + " trat ein Fehler auf: " + err.name + ".";
+                }
                 break;
             case TokenType.checkCast:
                 value = stack[stackTop];
@@ -952,6 +962,13 @@ export class Interpreter {
                 let secondOperand = stack.pop();
                 let resultValue =
                     node.leftType.compute(node.operator, stack[stackTop - 1], secondOperand);
+                if (resultValue instanceof Error) {
+                    if (resultValue.message) return resultValue.message;
+                    else "Bei der Berechnung von " + stack[stackTop - 1].type.identifier + " " +
+                        TokenTypeReadable[node.operator] + " " + secondOperand.type.identifier +
+                        " trat ein Fehler (" + resultValue.name + ") auf."
+
+                }
                 let resultType = node.leftType.getResultType(node.operator, secondOperand.type);
                 stack[stackTop - 1] = {
                     type: resultType,
@@ -1463,7 +1480,7 @@ export class Interpreter {
     }
 
     oldState: InterpreterState;
-    pauseForInput(){
+    pauseForInput() {
         this.timerStopped = true;
         this.additionalStepFinishedFlag = true;
         this.oldState = this.state;
@@ -1471,9 +1488,9 @@ export class Interpreter {
         this.showProgramPointerAndVariables();
     }
 
-    resumeAfterInput(value: Value, popPriorValue: boolean = false){
-        if(popPriorValue) this.stack.pop();
-        if(value != null) this.stack.push(value);
+    resumeAfterInput(value: Value, popPriorValue: boolean = false) {
+        if (popPriorValue) this.stack.pop();
+        if (value != null) this.stack.push(value);
         this.main.hideProgramPointerPosition();
         this.setState(InterpreterState.paused);
         if (this.oldState == InterpreterState.running) {
@@ -1867,7 +1884,7 @@ export class Interpreter {
     }
 
     registerDatabaseConnection(ch: ConnectionHelper) {
-        this.databaseConnectionHelpers.push(ch); 
+        this.databaseConnectionHelpers.push(ch);
     }
 
 

--- a/src/client/interpreter/Interpreter.ts
+++ b/src/client/interpreter/Interpreter.ts
@@ -1,4 +1,4 @@
-import { TextPosition, TokenType } from "../compiler/lexer/Token.js";
+import { TextPosition, TokenType, TokenTypeReadable } from "../compiler/lexer/Token.js";
 import { Module, ModuleStore } from "../compiler/parser/Module.js";
 import { Program, Statement, ReturnStatement } from "../compiler/parser/Program.js";
 import { ArrayType } from "../compiler/types/Array.js";
@@ -1364,7 +1364,10 @@ export class Interpreter {
                 let text = null;
                 let color = null;
                 if (node.withColor) color = <string | number>stack.pop().value;
-                if (!node.empty) text = <string>stack.pop().value;
+                if (!node.empty) {
+                    text = <string>stack.pop().value;
+                    if (text == null) text = "null";
+                }
                 if (node.type == TokenType.println) {
                     this.printManager.println(text, color);
                 } else {

--- a/src/client/runtimelibrary/graphics/Bitmap.ts
+++ b/src/client/runtimelibrary/graphics/Bitmap.ts
@@ -135,6 +135,42 @@ export class BitmapClass extends Klass {
 
             }, false, false, 'Setzt die Farbe des Pixels bei (x, y). Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)". 0.0 <= alpha <= 1.0.', false));
 
+        this.addMethod(new Method("setColor", new Parameterlist([
+            { identifier: "x", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "y", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let x: number = parameters[1].value;
+                let y: number = parameters[2].value;
+                let color: string = parameters[3].value;
+                let sh: BitmapHelperNew = o.intrinsicData["Actor"];
+
+                sh.setzeFarbe(x, y, color);
+
+            }, false, false, 'Setzt die Farbe des Pixels bei (x, y). Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)"', false));
+
+        this.addMethod(new Method("setColor", new Parameterlist([
+            { identifier: "x", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "y", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let x: number = parameters[1].value;
+                let y: number = parameters[2].value;
+                let color: string = parameters[3].value;
+                let alpha: number = parameters[4].value;
+                let sh: BitmapHelperNew = o.intrinsicData["Actor"];
+
+                sh.setzeFarbe(x, y, color, alpha);
+
+            }, false, false, 'Setzt die Farbe des Pixels bei (x, y). Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)". 0.0 <= alpha <= 1.0.', false));
+
         this.addMethod(new Method("isColor", new Parameterlist([
             { identifier: "x", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
             { identifier: "y", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -169,6 +205,23 @@ export class BitmapClass extends Klass {
 
             }, false, false, 'Gibt genau dann true zurück, wenn das Pixel bei (x, y) die angegebene Farbe besitzt. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
 
+        this.addMethod(new Method("isColor", new Parameterlist([
+            { identifier: "x", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "y", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true }
+        ]), booleanPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let x: number = parameters[1].value;
+                let y: number = parameters[2].value;
+                let color: RuntimeObject = parameters[3].value;
+                let sh: BitmapHelperNew = o.intrinsicData["Actor"];
+
+                return sh.istFarbe(x, y, color);
+
+            }, false, false, 'Gibt genau dann true zurück, wenn das Pixel bei (x, y) die angegebene Farbe besitzt. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
 
         this.addMethod(new Method("fillAll", new Parameterlist([
             { identifier: "color", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -184,6 +237,22 @@ export class BitmapClass extends Klass {
                 sh.fillAll(color, alpha);
 
             }, false, false, 'Füllt die ganze Bitmap mit einer Farbe. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
+        this.addMethod(new Method("fillAll", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let alpha: number = parameters[2].value;
+                let sh: BitmapHelperNew = o.intrinsicData["Actor"];
+
+                sh.fillAll(color, alpha);
+
+            }, false, false, 'Füllt die ganze Bitmap mit einer Farbe. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
 
         this.addMethod(new Method("fillAll", new Parameterlist([
             { identifier: "colorAsRGBAString", type: stringPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -261,8 +330,8 @@ export class BitmapHelperNew extends ShapeHelper {
 
         let uInt32 = new Uint32Array([0x11223344]);
         let uInt8 = new Uint8Array(uInt32.buffer);
-     
-        if(uInt8[0] === 0x44) {
+
+        if (uInt8[0] === 0x44) {
             this.isBigEndian = false;
         } else if (uInt8[0] === 0x11) {
             this.isBigEndian = true;
@@ -281,7 +350,7 @@ export class BitmapHelperNew extends ShapeHelper {
 
         let sprite = <PIXI.Sprite>this.displayObject;
 
-        sprite.localTransform.scale(width/anzahlX, height/anzahlY);
+        sprite.localTransform.scale(width / anzahlX, height / anzahlY);
         sprite.localTransform.translate(left, top);
         //@ts-ignore
         sprite.transform.onChange();
@@ -301,22 +370,22 @@ export class BitmapHelperNew extends ShapeHelper {
 
     protected initGraphics(bitmapToCopy?: BitmapHelperNew, clone: boolean = false) {
 
-        if(bitmapToCopy == null){
+        if (bitmapToCopy == null) {
             this.data = new Uint32Array(this.anzahlX * this.anzahlY);
         } else {
-            if(clone){
+            if (clone) {
                 this.data = bitmapToCopy.data;
             } else {
                 this.data = new Uint32Array(bitmapToCopy.data);
             }
         }
-        
+
         let u8Array = new Uint8Array(this.data.buffer);
 
-        if(!clone){
-            let bufferResource = new PIXI.BufferResource(u8Array, {width: this.anzahlX, height: this.anzahlY});
+        if (!clone) {
+            let bufferResource = new PIXI.BufferResource(u8Array, { width: this.anzahlX, height: this.anzahlY });
             let bt = new PIXI.BaseTexture(bufferResource, {
-                scaleMode: PIXI.SCALE_MODES.NEAREST 
+                scaleMode: PIXI.SCALE_MODES.NEAREST
             });
             this.texture = new PIXI.Texture(bt);
         } else {
@@ -327,7 +396,7 @@ export class BitmapHelperNew extends ShapeHelper {
         this.worldHelper.stage.addChild(this.displayObject);
     }
 
-    uploadData(){
+    uploadData() {
         this.texture.baseTexture.update();
     }
 
@@ -358,11 +427,15 @@ export class BitmapHelperNew extends ShapeHelper {
     }
 
 
-    public istFarbe(x: number, y: number, color: string | number, alpha?: number) {
+    public istFarbe(x: number, y: number, color: string | number | RuntimeObject, alpha?: number) {
 
         let i = (x + y * (this.anzahlX));
 
         let c: number;
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let ch = ColorHelper.parseColorToOpenGL(color);
@@ -378,14 +451,18 @@ export class BitmapHelperNew extends ShapeHelper {
         let blue = (c1 & 0xff0000) >> 16;
 
 
-        return c == red*0x10000 + green * 0x100 + blue;
+        return c == red * 0x10000 + green * 0x100 + blue;
 
     }
 
-    public setzeFarbe(x: number, y: number, color: string | number, alpha?: number) {
+    public setzeFarbe(x: number, y: number, color: string | number | RuntimeObject, alpha?: number) {
 
         let i = (x + y * (this.anzahlX));
         let c: number;
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let ch = ColorHelper.parseColorToOpenGL(color);
@@ -397,12 +474,16 @@ export class BitmapHelperNew extends ShapeHelper {
         }
 
         this.data[i] = Math.round(alpha * 255) * 0x1000000 + ((c & 0xff) << 16) + (c & 0xff00) + ((c & 0xff0000) >> 16);
-        
+
         this.uploadData();
     }
 
-    public fillAll(color: string | number, alpha?: number) {
+    public fillAll(color: string | number | RuntimeObject, alpha?: number) {
         let c: number;
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let ch = ColorHelper.parseColorToOpenGL(color);
@@ -414,12 +495,12 @@ export class BitmapHelperNew extends ShapeHelper {
 
         this.data.fill(Math.round(alpha * 255) * 0x1000000 + ((c & 0xff) << 16) + (c & 0xff00) + ((c & 0xff0000) >> 16));
         // this.data.fill(0xffff0000);
-        
+
         this.uploadData();
     }
-    
+
     public setzeFarbeRGBA(x: number, y: number, r: number, g: number, b: number, alpha: number) {
-        let c = alpha * 0xff000000 + b*0x10000 + g * 0x100 + r;
+        let c = alpha * 0xff000000 + b * 0x10000 + g * 0x100 + r;
         let i = (x + y * (this.anzahlX));
         this.data[i] = c;
         this.uploadData();

--- a/src/client/runtimelibrary/graphics/FilledShape.ts
+++ b/src/client/runtimelibrary/graphics/FilledShape.ts
@@ -87,21 +87,6 @@ export class FilledShapeClass extends Klass {
 
             }, false, false, 'Setzt die Durchsichtigkeit von Füllung und Rand. 0.0 bedeutet vollkommen durchsichtig, 1.0 bedeutet vollkommen undurchsichtig."', false));
 
-        this.addMethod(new Method("setFillColor", new Parameterlist([
-            { identifier: "color", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true }
-        ]), voidPrimitiveType,
-            (parameters) => {
-
-                let o: RuntimeObject = parameters[0].value;
-                let color: number = parameters[1].value;
-                let sh: FilledShapeHelper = o.intrinsicData["Actor"];
-
-                if (sh.testdestroyed("setFillColor")) return;
-
-                sh.setFillColor(color);
-
-            }, false, false, 'Setzt die Füllfarbe. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau', false));
-
         this.addMethod(new Method("setDefaultBorder", new Parameterlist([
             { identifier: "width", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
             { identifier: "color", type: stringPrimitiveType, declaration: null, usagePositions: null, isFinal: true }
@@ -130,6 +115,36 @@ export class FilledShapeClass extends Klass {
 
             }, false, true, 'Setzt Default-Eigenschaften des Randes. Sie werden nachfolgend immer dann verwendet, wenn ein neues grafisches Objekt erstellt wird. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
 
+        this.addMethod(new Method("setDefaultBorder", new Parameterlist([
+            { identifier: "width", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let width: number = parameters[1].value;
+                let color: RuntimeObject = parameters[2].value;
+                let alpha: number = parameters[3].value;
+
+                FilledShapeDefaults.setDefaultBorder(width, color, alpha);
+
+            }, false, true, 'Setzt Default-Eigenschaften des Randes. Sie werden nachfolgend immer dann verwendet, wenn ein neues grafisches Objekt erstellt wird. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
+
+        this.addMethod(new Method("setDefaultBorder", new Parameterlist([
+            { identifier: "width", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true }
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let width: number = parameters[1].value;
+                let color: RuntimeObject = parameters[2].value;
+                let alpha: number = parameters[3].value;
+
+                FilledShapeDefaults.setDefaultBorder(width, color);
+
+            }, false, true, 'Setzt Default-Eigenschaften des Randes. Sie werden nachfolgend immer dann verwendet, wenn ein neues grafisches Objekt erstellt wird. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
         this.addMethod(new Method("setDefaultFillColor", new Parameterlist([
             { identifier: "color", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
             { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -153,6 +168,46 @@ export class FilledShapeClass extends Klass {
                 FilledShapeDefaults.setDefaultFillColor(color);
 
             }, false, true, 'Setzt die Default-Füllfarbe. Sie wird nachfolgend immer dann verwendet, wenn ein neues grafisches Objekt erstellt wird. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
+        this.addMethod(new Method("setDefaultFillColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let color: RuntimeObject = parameters[1].value;
+                let alpha: number = parameters[2].value;
+
+                FilledShapeDefaults.setDefaultFillColor(color, alpha);
+
+            }, false, true, 'Setzt die Default-Füllfarbe. Sie wird nachfolgend immer dann verwendet, wenn ein neues grafisches Objekt erstellt wird. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
+        this.addMethod(new Method("setDefaultFillColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let color: RuntimeObject = parameters[1].value;
+
+                FilledShapeDefaults.setDefaultFillColor(color);
+
+            }, false, true, 'Setzt die Default-Füllfarbe. Sie wird nachfolgend immer dann verwendet, wenn ein neues grafisches Objekt erstellt wird. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau und 0.0 <= alpha <= 1.0', false));
+
+        this.addMethod(new Method("setFillColor", new Parameterlist([
+            { identifier: "color", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true }
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: number = parameters[1].value;
+                let sh: FilledShapeHelper = o.intrinsicData["Actor"];
+
+                if (sh.testdestroyed("setFillColor")) return;
+
+                sh.setFillColor(color);
+
+            }, false, false, 'Setzt die Füllfarbe. Die Farbe wird als int-Wert gegeben, wobei farbe == 255*255*rot + 255*grün + blau', false));
+
 
         this.addMethod(new Method("setFillColor", new Parameterlist([
             { identifier: "color", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -202,6 +257,39 @@ export class FilledShapeClass extends Klass {
                 sh.setFillColor(color, alpha);
 
             }, false, false, 'Setzt die Füllfarbe. Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" oder "rgb(172, 22, 18)" und 0.0 <= alpha <= 1.0"', false));
+
+        this.addMethod(new Method("setFillColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let sh: FilledShapeHelper = o.intrinsicData["Actor"];
+
+                if (sh.testdestroyed("setFillColor")) return;
+
+                sh.setFillColor(color);
+
+            }, false, false, 'Setzt die Füllfarbe. Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)"', false));
+
+        this.addMethod(new Method("setFillColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let alpha: number = parameters[2].value;
+                let sh: FilledShapeHelper = o.intrinsicData["Actor"];
+
+                if (sh.testdestroyed("setFillColor")) return;
+
+                sh.setFillColor(color, alpha);
+
+            }, false, false, 'Setzt die Füllfarbe. Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" oder "rgb(172, 22, 18)" und 0.0 <= alpha <= 1.0"', false));
+
 
         this.addMethod(new Method("setBorderColor", new Parameterlist([
             { identifier: "color", type: intPrimitiveType, declaration: null, usagePositions: null, isFinal: true }
@@ -266,6 +354,39 @@ export class FilledShapeClass extends Klass {
                 sh.setBorderColor(color);
 
             }, false, false, 'Setzt die Randfarbe. Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)"', false));
+
+        this.addMethod(new Method("setBorderColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+            { identifier: "alpha", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let alpha: number = parameters[2].value;
+                let sh: FilledShapeHelper = o.intrinsicData["Actor"];
+
+                if (sh.testdestroyed("setBorderColor")) return;
+
+                sh.setBorderColor(color, alpha);
+
+            }, false, false, 'Setzt die Randfarbe. Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" oder "rgb(172, 22, 18)" und 0.0 <= alpha <= 1.0"', false));
+
+        this.addMethod(new Method("setBorderColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let sh: FilledShapeHelper = o.intrinsicData["Actor"];
+
+                if (sh.testdestroyed("setBorderColor")) return;
+
+                sh.setBorderColor(color);
+
+            }, false, false, 'Setzt die Randfarbe. Die Farbe ist entweder eine vordefinierte Farbe (Color.black, Color.red, ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)"', false));
+
 
         this.addMethod(new Method("setBorderWidth", new Parameterlist([
             { identifier: "widthInPixel", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -337,7 +458,11 @@ export abstract class FilledShapeHelper extends ShapeHelper {
         this.render();
     }
 
-    setBorderColor(color: string | number, alpha?: number) {
+    setBorderColor(color: string | number | RuntimeObject, alpha?: number) {
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let c = ColorHelper.parseColorToOpenGL(color);
@@ -352,7 +477,11 @@ export abstract class FilledShapeHelper extends ShapeHelper {
 
     }
 
-    setFillColor(color: string | number, alpha?: number) {
+    setFillColor(color: string | number | RuntimeObject, alpha?: number) {
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let c = ColorHelper.parseColorToOpenGL(color);

--- a/src/client/runtimelibrary/graphics/FilledShapeDefaults.ts
+++ b/src/client/runtimelibrary/graphics/FilledShapeDefaults.ts
@@ -1,4 +1,4 @@
-import { RuntimeObject } from "src/client/interpreter/RuntimeObject.js";
+import { RuntimeObject } from "../../interpreter/RuntimeObject.js";
 import { ColorClassIntrinsicData } from "./Color.js";
 import { ColorHelper } from "./ColorHelper.js";
 

--- a/src/client/runtimelibrary/graphics/FilledShapeDefaults.ts
+++ b/src/client/runtimelibrary/graphics/FilledShapeDefaults.ts
@@ -1,3 +1,5 @@
+import { RuntimeObject } from "src/client/interpreter/RuntimeObject.js";
+import { ColorClassIntrinsicData } from "./Color.js";
 import { ColorHelper } from "./ColorHelper.js";
 
 export class FilledShapeDefaults {
@@ -10,10 +12,10 @@ export class FilledShapeDefaults {
 
     static defaultVisibility: boolean = true;
 
-    static initDefaultValues(){
+    static initDefaultValues() {
         FilledShapeDefaults.defaultFillColor = 0x8080ff;
         FilledShapeDefaults.defaultFillAlpha = 1.0;
-    
+
         FilledShapeDefaults.defaultBorderColor = null;
         FilledShapeDefaults.defaultBorderAlpha = 1.0;
         FilledShapeDefaults.defaultBorderWidth = 10;
@@ -25,9 +27,13 @@ export class FilledShapeDefaults {
         FilledShapeDefaults.defaultVisibility = visibility;
     }
 
-    static setDefaultBorder(width: number, color: string | number, alpha?: number) {
+    static setDefaultBorder(width: number, color: string | number | RuntimeObject, alpha?: number) {
 
         FilledShapeDefaults.defaultBorderWidth = width;
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let c = ColorHelper.parseColorToOpenGL(color);
@@ -40,7 +46,11 @@ export class FilledShapeDefaults {
 
     }
 
-    static setDefaultFillColor(color: string | number, alpha?: number) {
+    static setDefaultFillColor(color: string | number | RuntimeObject, alpha?: number) {
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let c = ColorHelper.parseColorToOpenGL(color);

--- a/src/client/runtimelibrary/graphics/Shape.ts
+++ b/src/client/runtimelibrary/graphics/Shape.ts
@@ -14,6 +14,7 @@ import { CircleHelper } from "./Circle.js";
 import { TurtleHelper } from "./Turtle.js";
 import { Enum, EnumInfo } from "../../compiler/types/Enum.js";
 import { FilledShapeDefaults } from "./FilledShapeDefaults.js";
+import { ColorClassIntrinsicData } from "./Color.js";
 
 export class ShapeClass extends Klass {
 
@@ -28,6 +29,7 @@ export class ShapeClass extends Klass {
         let shapeType = module.typeStore.getType("Shape");
         let directionType = <Enum>(<any>module.typeStore.getType("Direction"));
         let shapeArrayType = new ArrayType(shapeType);
+        let colorType: Klass = <Klass>this.module.typeStore.getType("Color");
 
         let vector2Class = <Klass>module.typeStore.getType("Vector2");
 
@@ -550,6 +552,22 @@ export class ShapeClass extends Klass {
 
             }, false, false, 'Überzieht das Grafikobjekt mit einer halbdurchsichtigen Farbschicht. Die Farbe wird als int-Wert angegeben, praktischerweise hexadezimal, also z.B. tint(0x303030).', false));
 
+        this.addMethod(new Method("tint", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let sh: ShapeHelper = o.intrinsicData["Actor"];
+
+                if (sh.testdestroyed("tint")) return;
+
+                sh.tint(color);
+
+            }, false, false, 'Überzieht das Grafikobjekt mit einer halbdurchsichtigen Farbschicht. Die Farbe wird als int-Wert angegeben, praktischerweise hexadezimal, also z.B. tint(0x303030).', false));
+
+
         this.addMethod(new Method("startTrackingEveryMouseMovement", new Parameterlist([
         ]), voidPrimitiveType,
             (parameters) => {
@@ -829,8 +847,11 @@ export abstract class ShapeHelper extends ActorHelper {
         }
     }
 
-    tint(color: string | number) {
+    tint(color: string | number | RuntimeObject) {
         let c: number;
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
         if (typeof color == 'string') {
             c = ColorHelper.parseColorToOpenGL(color).color;
         } else {

--- a/src/client/runtimelibrary/graphics/World.ts
+++ b/src/client/runtimelibrary/graphics/World.ts
@@ -5,6 +5,7 @@ import { Method, Parameterlist, Value } from "../../compiler/types/Types.js";
 import { Interpreter, InterpreterState } from "../../interpreter/Interpreter.js";
 import { RuntimeObject } from "../../interpreter/RuntimeObject.js";
 import { ActorHelper } from "./Actor.js";
+import { ColorClassIntrinsicData } from "./Color.js";
 import { ColorHelper } from "./ColorHelper.js";
 import { FilledShapeDefaults } from "./FilledShapeDefaults.js";
 import { GroupClass, GroupHelper } from "./Group.js";
@@ -23,6 +24,7 @@ export class WorldClass extends Klass {
         let groupType = <GroupClass>module.typeStore.getType("Group");
         let shapeType = <ShapeClass>module.typeStore.getType("Shape");
         let mouseListenerType = <MouseListenerInterface>module.typeStore.getType("MouseListener");
+        let colorType: Klass = <Klass>this.module.typeStore.getType("Color");
 
         // this.addAttribute(new Attribute("PI", doublePrimitiveType, (object) => { return Math.PI }, true, Visibility.public, true, "Die Kreiszahl Pi (3.1415...)"));
 
@@ -75,6 +77,20 @@ export class WorldClass extends Klass {
                 wh.setBackgroundColor(color);
 
             }, false, false, 'Setzt die Hintergrundfarbe. Die Farbe ist entweder eine vordefinierte Farbe ("schwarz", "rot", ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)"', false));
+
+        this.addMethod(new Method("setBackgroundColor", new Parameterlist([
+            { identifier: "color", type: colorType, declaration: null, usagePositions: null, isFinal: true },
+        ]), voidPrimitiveType,
+            (parameters) => {
+
+                let o: RuntimeObject = parameters[0].value;
+                let color: RuntimeObject = parameters[1].value;
+                let wh: WorldHelper = o.intrinsicData["World"];
+
+                wh.setBackgroundColor(color);
+
+            }, false, false, 'Setzt die Hintergrundfarbe. Die Farbe ist entweder eine vordefinierte Farbe ("schwarz", "rot", ...) oder eine css-Farbe der Art "#ffa7b3" (ohne alpha), "#ffa7b380" (mit alpha), "rgb(172, 22, 18)" oder "rgba(123, 22,18, 0.3)"', false));
+
 
         this.addMethod(new Method("move", new Parameterlist([
             { identifier: "x", type: doublePrimitiveType, declaration: null, usagePositions: null, isFinal: true },
@@ -797,7 +813,11 @@ export class WorldHelper {
 
     }
 
-    setBackgroundColor(color: string | number) {
+    setBackgroundColor(color: string | number | RuntimeObject) {
+
+        if (color instanceof RuntimeObject) {
+            color = (<ColorClassIntrinsicData>(color.intrinsicData)).hex;
+        }
 
         if (typeof color == "string") {
             let c = ColorHelper.parseColorToOpenGL(color);

--- a/src/client/tools/StringTools.ts
+++ b/src/client/tools/StringTools.ts
@@ -63,3 +63,11 @@ export function formatAsJavadocComment(s: string, indent: number|string = ""): s
   s = indentString + "/**" + s.replace(/\n/g, "\n" + indentString + " * ") + "\n" + indentString + " */";
   return s;
 }
+
+export function nullToString(s: string) {
+  return s == null ? "null" : s;
+}
+
+export function floatToString(val: number){
+  return val + (Number.isInteger(val)? ".0": "");
+}


### PR DESCRIPTION
I noticed several bugs regarding casts, automatic `toString()` and `null`, i.e. behaviours that differ from the behaviour in Java.
I'm not sure, whether some of the differences are on purpose (it's not a bug, it's a feature).
If so, I suggest to add these differences to the page [`LernJ vs. Java: Unterschiede`](https://www.learnj.de/doku.php?id=unterschiede_zu_java:start) in the documentation instead.
As the problems are unfortunately very closely interwoven, there were quite a lot of changes in the interpreter and the compiler nescessary.
They are primarily meant as suggestions to be discussed. This is why I created this pull request only as draft. 
While some changes (like b5c3a53) can probably be adopted directly, you may have better suggestions for other problems.

In the following I listed the bugs and how I fixed them in a table:

## Bugs

<table>
    <thead>
        <th>Bug</th><th>Example</th><th>Output</th><th>Expected</th><th>Analysis</th><th>Fix</th>
    </thead>
    <tbody>
        <tr>
            <td><code>1d</code> and <code>1f</code> are <code>int</code>s</td>
            <td><pre lang="java">println(3 / 2d);</pre></td>
            <td><code>1</code></td><td><code>1.5</code></td>
            <td>There is an syntax error (<code>==</code> instead of <code>=</code>)
            in <a href="https://github.com/martin-pabst/Online-IDE/blob/master/src/client/compiler/lexer/Lexer.ts#L917">line 917</a> of the lexer.
            <td>b5c3a53</td>
        </tr>
        <tr>
            <td>String representation of <code>double</code>s and <code>float</code>s</td>
            <td><pre lang="java">println(3.);</pre></td>
            <td><code>3.0</code></td><td><code>3</code></td>
            <td>In normal java, when printing <code>double</code>s or <code>float</code>s, that are ∈ ℤ, they end on <code>.0</code>.
            Since javascript only knows one <code>number</code> type, this has to be done manually.
            <td>This was by accident split up in multiple commits and mixed with other changes<ul>
                <li>5c2f340: aux. function <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/tools/StringTools.ts#L71-L73"><code>floatToString()</code></a></li>
                <li>5c2f340: The function <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/types/Types.ts#L96-L98"><code>valueToString()</code></a> in <code>PrimitiveType</code> called by <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/parser/CodeGenerator.ts#L881"><code>ensureAutomaticToString</code></a> in <code>CodeGenerator.ts</code> is overwritten in <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/types/PrimitiveTypes.ts#L348-L350"><code>FloatPrimitiveType</code></a> and <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/types/PrimitiveTypes.ts#L472-L474"><code>DoublePrimitiveType</code></a>, so that it calls <code>floatToString()</code>.</li>
                <li>ec0a6e9: changed non-static <code>toString()</code>-methods of <a href="https://github.com/martin-pabst/Online-IDE/blob/ec0a6e939b16b8fafddeabfa2b9714aadd1414f3/src/client/compiler/types/boxedTypes/DoubleClass.ts#L89"><code>DoubleClass</code></a> and <a href="https://github.com/martin-pabst/Online-IDE/blob/ec0a6e939b16b8fafddeabfa2b9714aadd1414f3/src/client/compiler/types/boxedTypes/FloatClass.ts#L89"><code>FloatClass</code></a></li>
                <li>ea4b168: changed static <code>toString()</code>-methods of <code>DoubleClass</code> and <code>FloatClass</code> </li>
            </ul></td>
        </tr>
        <tr>
        <td>Casting from <code>Integer</code> to <code>long</code> </td>
        <td><pre lang="java">println((long)(Integer) 1); </pre></td>
        <td><i>compiler error:</i><code> Der Datentyp Integer kann (zumindest durch casting) nicht in den Datentyp long umgewandelt werden.</code></td><td><code>1</code></td>
        <td><code>longPrimitiveType</code> is missing in <code>unboxableAs</code> of <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/types/boxedTypes/IntegerClass.ts#L30"><code>IntegerClass</code></a></td>
        <td><ul>
        <li>dc08466: added <code>longPrimitiveType</code></li>
        <li>ed88f6e: added <code>"Long"</code> to the <a href="https://github.com/martin-pabst/Online-IDE/blob/ed88f6e7d335a2b085c0ed1c410e1b60d9fc0190/src/client/compiler/types/PrimitiveTypes.ts#L121"><code>canCastToMap</code> of <code>IntPrimitiveType</code></a> (Although in Java it is not possible to cast an <code>int</code> to a <code>Long</code>, I think this makes sense, as there is no real difference, since everything is stored as javascript-number internally, and in the Online IDE it is also possible to cast a <code>float</code> to a <code>Double</code>) </li>
        </ul></td>
        </tr>
        <tr>
            <td rowspan="2">String representation of <code>null</code></td>
            <td><pre lang="java">println(null);</pre></td>
            <td><i>leere Zeile</i></td><td rowspan="2"><code>null</code></td>
            <td >The <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/main/gui/PrintManager.ts#L231"><code>PrintManager</code></a> prints an empty line, when <code>text == null</code>.</td>
            <td rowspan>5c2f340: Before the <code>Interpreter</code> calls the <code>PrintManager</code>, it checks, whether <code>println</code> is called without parameters,
            than still <code>null</code> is passed, or if it is called with <code>null</code> as parameter, than <code>"null"</code> is passed.</td>
            </tr><tr>
            <td><pre lang="java">println((Rectangle)null);</pre></td>
            <td><i>run time error:</i> <code>Fehler: Aufruf der Methode toString des null-Objekts</code></td>
            <td>The automatic conversion to a <code>String</code> in  the current version is done in <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/parser/CodeGenerator.ts#L876"><code>getToStringStatement()</code>, which inserts a call of the <code>toString()</code>-method of the respective class.</td>
            <td>5c2f340: The new method <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/parser/CodeGenerator.ts#L873"><code>ensureAutomaticToString()</code></a> is a bit more complex, but considers this and other cases. Instead of inserting an call of the <code>toString()</code> of the respective class, a  call of an <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/parser/CodeGenerator.ts#L895-L899">artifical method</a> is inserted, which is static and first catches the case, that the parameter is <code>null</code> (then <code>"null"</code> is returned), before invoking the actual <code>toString()</code> method of the respective class.</td>
        </tr>
        <tr>
            <td>Concatenation of strings</td>
            <td><pre lang="java">println((String)null + (String)null);</pre></td>
            <td><code>0</code></td><td><code>nullnull</code></td>
            <td>The problem is, that in javascript <code>null + null = 0</code> (don't ask me why). So it has to be fixed, where in the <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/types/PrimitiveTypes.ts#L833-L840"><code>compute()</code></a> method of <code>StringPrimitiveType</code></td>
            <td>5c2f340: If the first operand is <code>null</code>, now <code>"null"</code> is used instead of it. Additionally a string now onlys concatenation with other strings (5c2f340, 97c862b). If one of the operands is no string, it is automatically converted to a string in <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/parser/CodeGenerator.ts#L873"><code>ensureAutomaticToString()</code></a>.</td>
        </tr>
        <tr>
            <td>Comparison with <code>null</code></td>
            <td><pre lang="java">println(null == (Circle) null);</pre></td>
            <td><i>compiler error:</i> <code>Die Operation == ist für die Operanden der Typen null und Circle nicht definiert.</code></td>
            <td><code>true</code></td>
            <td>The <code>NullType</code> allows no operations at all, since <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/types/PrimitiveTypes.ts#L20"><code>getResultType()</code></a> always returns <code>null</code>.</td>
            <td>c6fb642: The <code>NullType</code> now allows the operations <code>TokenType.equal</code> and <code>TokenType.notEqual</code>, if the <code>secondOperandType</code> allows this operation with the <code>NullType</code> (so if the operation works the other way around). For both operations <code>compute()</code> was implemented.</td>
        </tr>
        <tr>
            <td>Casting an <code>null</code> Object to a primitive type</td>
            <td><pre lang="java">double a = (Double) null;</pre></td>
            <td><i>no error</i></td><td><i>an error</i></td>
            <td>In the current version of <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/parser/CodeGenerator.ts#L841-L843">ensureAutomaticCasting()</a>, if the type can be unboxed, it simply returns <code>true</code> without inserting statements. Thus, at run time it won't be checked, whether the unboxed value is <code>null</code>.</td>
            <td><ul>
                <li>5d4b55a, 0fbeaf2: <a href="https://github.com/martin-pabst/Online-IDE/blob/0fbeaf284adeeaee253d1ee3f6c65a66718b4fa0/src/client/compiler/parser/CodeGenerator.ts#L835-L840">ensureAutomaticCasting()</a> now always inserts a cast statement (except for the case that the types are equal).</li>
                <li>ec0a6e9, 0fbeaf2: All boxed types now inherit from the new class <a href="https://github.com/martin-pabst/Online-IDE/blob/0fbeaf284adeeaee253d1ee3f6c65a66718b4fa0/src/client/compiler/types/Class.ts#L1491"><code>UnboxableKlass</code></a>. This class implements <code>castTo()</code> and <code>canCastTo()</code>. <code>castTo()</code> will throw an error, when the casted <code>value</code> is <code>null</code>.</li>
                <li>5d4b55a: The <a href="https://github.com/martin-pabst/Online-IDE/blob/5d4b55aa620d333028a27f180b6b10ab38f963c3/src/client/interpreter/Interpreter.ts#L833-L847"><code>Interpreter</code></a> will catch this error and display it.</li>
            </ul></td>
        </tr>
        <tr>
            <td>Automatic casting / conversion to string </td>
            <td><pre lang="java">String s = new Rectangle(0,0,0,0); println(s);</pre></td>
            <td><code>(Rectangle)</code></td><td><i>an error</i></td>
            <td>In the current version you can cast everything to a <code>String</code> (due to <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/types/Class.ts#L625-L627"> lines 625-627 </a> in <code>Klass.canCastTo()</code>) and everything can be automatically casted to a string (due to <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/parser/CodeGenerator.ts#L847-L852">line 847-852</a> in <code>ensureAutomaticCasting</code> in the <code>CodeGenerator.ts</code>). I'm not sure whether this is an feature or a bug. However it don't think it makes sense, since <ol>
                <li>it is not possible in Java</li>
                <li>it breaks with the logic of casting</li>
                <li>you can use <code>toString()</code> or <code>+""</code> instead</li>
            </ol></td>
            <td><ul>
                <li>5c2f340: removed the lines, that allowed to cast any object to a <code>String</code> (in <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/types/Class.ts#L625-L627"> Klass </a> as well as in the primitive types)</li>
                <li>5c2f340: new method <a href="https://github.com/martin-pabst/Online-IDE/blob/5c2f3400207b5369023fb2dad3e3ad3001b8b388/src/client/compiler/parser/CodeGenerator.ts#L873"><code>ensureAutomaticToString()</code></a>, that takes care of the auto-conversion when calling <code>print</code> or concatenating with a <code>String</code></li>
                <li>5d4b55a: removed the <a href="https://github.com/martin-pabst/Online-IDE/blob/b34ff63e3509796a0df18bbb25e2ad30b23a9f34/src/client/compiler/parser/CodeGenerator.ts#L847-L852">lines in <code>CodeGenerator.ts</code></a>, that allowed auto-casting to a <code>String</code></li>
                <li>b785877: Because without auto-casting to <code>String</code> something like <code>setFillColor(Color.red)</code> wouldn't work anymore, I added corresponding methods that accept a <code>Color</code>-object as parameter.</li>
            </ul></td>
    </tbody>
</table>

You can try out the fixed version in my embedded IDE: <a href="https://informa-tiger.github.io/Online-IDE/htdocs/ide?script=https://raw.githubusercontent.com/Informa-Tiger/online-ide-projects/main/embedded_examples/pr_56_casts_toString_null_etc.java" target="_blank">**🡭 Start in IDE**</a>

Please comment on which of these changes make sense and for which a better solution should be found.